### PR TITLE
Allow running single commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -269,7 +269,7 @@ func main() {
 			}
 		}
 
-		if len(*cmd) > 1 {
+		if len(*cmd) >= 1 {
 			os.Setenv("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
 			os.Setenv("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
 			if len(creds.SessionToken) > 0 {


### PR DESCRIPTION
This should fix a kind of strange bug where you couldn't run a command that didn't take any arguments.

Old:
```
~/Downloads/aws-runas-0.1.4-darwin-amd64 aiprimary ls
export AWS_ACCESS_KEY_ID='XXXXX'
export AWS_SECRET_ACCESS_KEY='XXXX'
export AWS_SESSION_TOKEN='XXXX'
export AWS_SECURITY_TOKEN='XXXX'
```

New:
```
./aws-runas-0.1.4-darwin-amd64 aiprimary ls
AWSConfigParser.go		LICENSE				aws-runas-0.1.4-darwin-amd64	main.go
```