### PR TITLE
Humanize the credential expiry time

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/alecthomas/template"
-  packages = [".","parse"]
+  packages = [
+    ".",
+    "parse"
+  ]
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
@@ -15,9 +18,40 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/iam","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/iam",
+    "service/sts"
+  ]
   revision = "ce8d7a13a9e7f883d91c39eb98d4f72021eb48e2"
   version = "v1.12.56"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  revision = "bb3d318650d48840a39aa21a027c6630e198e626"
 
 [[projects]]
   name = "github.com/go-ini/ini"
@@ -44,6 +78,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d61182877de8020397ad67dfd3d82e4cb17f932f16dcf914d6dcf645a377c575"
+  inputs-digest = "907aee9f0864ee89db3f324a571decf5a572a89ee2232eac63abb2ba993f5058"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	humanize "github.com/dustin/go-humanize"
 	"github.com/mbndr/logo"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
@@ -258,8 +259,11 @@ func main() {
 
 		if *showExpire {
 			exp_t := credProvider.ExpirationTime()
-			fmt.Printf("Session credentials will expire on %s (%s)\n", exp_t, exp_t.Sub(time.Now()).Round(time.Second))
-			os.Exit(0)
+			sentance_tense := "will expire"
+			if exp_t.Before(time.Now()) {
+				sentance_tense = "expired"
+			}
+			fmt.Printf("Session credentials %s %s\n", sentance_tense, humanize.Time(exp_t))
 		}
 
 		if !*sesCreds {


### PR DESCRIPTION
This just enhances the output of the `-e` flag to be a little more readable. Also, it allows you to also run a command.

Old:
```
$ ~/Downloads/aws-runas-0.1.4-darwin-amd64 -e aiprimary ./development-environment.sh 
Session credentials will expire on 2018-02-03 04:18:38 -0700 MST (11h1m36s)
```

New:
```
$ ./aws-runas-0.1.4-1-g077de28-darwin-amd64 aiprimary -e echo "hi"
Session credentials will expire 10 hours from now
hi
```