### PR TITLE
Bugfix/25

### DIFF
--- a/lib/assume_role_provider.go
+++ b/lib/assume_role_provider.go
@@ -57,7 +57,9 @@ func NewAssumeRoleProvider(profile *AWSProfile, opts *CachedCredentialsProviderO
 	if len(suffix) < 1 || suffix == "default" {
 		acctNum := profile.RoleArn.AccountID
 		roleParts := strings.Split(profile.RoleArn.Resource, "/")
-		suffix = fmt.Sprintf("%s-%s", acctNum, roleParts[len(roleParts)-1])
+		if len(acctNum) > 0 {
+			suffix = fmt.Sprintf("%s-%s", acctNum, roleParts[len(roleParts)-1])
+		}
 	}
 	opts.cacheFileName = fmt.Sprintf(".aws_assume_role_%s", suffix)
 

--- a/lib/assume_role_provider_test.go
+++ b/lib/assume_role_provider_test.go
@@ -20,8 +20,9 @@ func TestNewAssumeRoleProvider(t *testing.T) {
 
 	t.Run("OptionsNil", func(t *testing.T) {
 		p := NewAssumeRoleProvider(new(AWSProfile), nil)
-		if !strings.HasSuffix(p.(*assumeRoleProvider).cacher.CacheFile(), "_") {
-			t.Errorf("Unexpected value returned calling NewAssumeRoleParty with nil options")
+		cache := p.(*assumeRoleProvider).cacher.CacheFile()
+		if !strings.HasSuffix(cache, "_") {
+			t.Errorf("Unexpected value returned calling NewAssumeRoleProvider with nil options: %v", cache)
 		}
 	})
 }


### PR DESCRIPTION
Fix #25 by creating a credential cache file based on AWS account number and role name, provided by the role ARN passed by the user.

Also fixed the case where the -r option would not remove cached credentials when used in conjunction with the --ec2 option