### PR TITLE
Add --ecs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Pre-compiled binaries for various platforms can be downloaded [here](https://git
     Flags:
       -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
           --ec2                      Run a mock EC2 metadata service to provide role credentials
+          --ecs                      Run a mock ECS credential endpoint to provide role credentials
       -v, --verbose                  Print verbose/debug messages
       -E, --env                      Pass credentials to program as environment variables
       -e, --expiration               Show credential expiration time

--- a/args.go
+++ b/args.go
@@ -19,6 +19,7 @@ var (
 	refresh      *bool
 	sesCreds     *bool
 	whoAmI       *bool
+	ecsMdFlag    *bool
 	duration     *time.Duration
 	roleDuration *time.Duration
 	mfaCode      *string
@@ -76,10 +77,12 @@ func init() {
 		fwdPortDesc         = "The local port for the forwarded connection"
 		outputArgDesc       = "Credential output format, valid values: env (default) or json"
 		whoAmIArgDesc       = "Print the AWS identity information for the provided profile"
+		ecsArgDesc          = "Run a mock ECS credential endpoint to provide role credentials"
 	)
 
 	// special flags
 	ec2MdFlag = kingpin.Flag("ec2", ec2ArgDesc).Bool()
+	ecsMdFlag = kingpin.Flag("ecs", ecsArgDesc).Bool()
 	verbose = kingpin.Flag("verbose", verboseArgDesc).Short('v').Envar("RUNAS_VERBOSE").Bool()
 	envFlag = kingpin.Flag("env", envArgDesc).Short('E').Envar("RUNAS_ENV_CREDENTIALS").Bool()
 	showExpire = kingpin.Flag("expiration", showExpArgDesc).Short('e').Bool()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,7 @@ Create an environment for interacting with the AWS API using an assumed role
 Flags:
   -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
       --ec2                      Run a mock EC2 metadata service to provide role credentials
+      --ecs                      Run a mock ECS credential endpoint to provide role credentials
   -v, --verbose                  Print verbose/debug messages
   -E, --env                      Pass credentials to program as environment variables
   -e, --expiration               Show credential expiration time

--- a/main.go
+++ b/main.go
@@ -180,6 +180,18 @@ func main() {
 				log.Fatalf("Error getting credentials: %v", err)
 			}
 
+			if *ecsMdFlag {
+				signal.Reset(os.Interrupt, syscall.SIGTERM) // reset signal handler
+				in := &metadata.EcsMetadataInput{Credentials: c, Logger: log, Port: 12319}
+				s, err := metadata.NewEcsMetadataService(in)
+				if err != nil {
+					log.Fatal(err)
+				}
+				log.Infof("ECS credential endpoint: %s", s.Url.String())
+				log.Infof("Set the AWS_CONTAINER_CREDENTIALS_FULL_URI environment variable with this value to allow programs to use it")
+				s.Run()
+			}
+
 			updateEnv(creds)
 			cmd := *execArgs.cmd
 


### PR DESCRIPTION
Add the --ecs flag to create an endpoint on the local system which can be used to get credentials for a profile.

Unlike the EC2 metadata feature, using the --ec2 flag, this new ECS feature does not require sudo/admin privileges on the host to run, since it uses an existing network interface (localhost), and a high-numbered port.  However, the AWS libraries do not automatically know this endpoint address (like it does with the hard-coded http://169.254.169.254/ endpoint for the EC2 metadata service), so you are required to set the `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable for the programs you are running to use this endpoint.

Fixes #54 