### PR TITLE
Update quickstart.md - Windows installation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,8 +63,7 @@ source /path/to/aws-runas-zsh-completion
 
 #### Windows
 
-After downloading the ZIP file, unzip it and move the extracted `aws-runas.exe` file to a location where it is
-easily accessible, like on the desktop, or in your home directory.
+After downloading the ZIP file, unzip it and move the extracted `aws-runas.exe` file to the home directory `%USERPROFILE%\.aws`
 
 ### Configuration
 


### PR DESCRIPTION
The Windows executable needs to be in the home directory with the .aws folder otherwise it will not run. Updated line 66 with this distinction.