### PR TITLE
Bug/metadata server mergein

### DIFF
--- a/metadata/server.go
+++ b/metadata/server.go
@@ -33,13 +33,12 @@ import (
 	"text/template"
 
 	"github.com/aws/smithy-go/logging"
-	"github.com/syndtr/gocapability/capability"
-
 	"github.com/mmmorris1975/aws-runas/client"
 	"github.com/mmmorris1975/aws-runas/config"
 	"github.com/mmmorris1975/aws-runas/credentials"
 	"github.com/mmmorris1975/aws-runas/credentials/helpers"
 	"github.com/mmmorris1975/aws-runas/shared"
+	"github.com/syndtr/gocapability/capability"
 )
 
 const (
@@ -662,7 +661,6 @@ func (s *metadataCredentialService) getConfigAndClient(profile string) (cfg *con
 
 	if s.awsConfig != nil {
 		s.awsConfig.MergeIn(cfg)
-		//cfg.MergeIn(s.awsConfig)
 	}
 
 	// ewww, testing-specific code in actual code

--- a/metadata/server.go
+++ b/metadata/server.go
@@ -19,13 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/smithy-go/logging"
-	"github.com/mmmorris1975/aws-runas/client"
-	"github.com/mmmorris1975/aws-runas/config"
-	"github.com/mmmorris1975/aws-runas/credentials"
-	"github.com/mmmorris1975/aws-runas/credentials/helpers"
-	"github.com/mmmorris1975/aws-runas/shared"
-	"github.com/syndtr/gocapability/capability"
 	"io"
 	"net"
 	"net/http"
@@ -38,6 +31,15 @@ import (
 	"sync"
 	"syscall"
 	"text/template"
+
+	"github.com/aws/smithy-go/logging"
+	"github.com/syndtr/gocapability/capability"
+
+	"github.com/mmmorris1975/aws-runas/client"
+	"github.com/mmmorris1975/aws-runas/config"
+	"github.com/mmmorris1975/aws-runas/credentials"
+	"github.com/mmmorris1975/aws-runas/credentials/helpers"
+	"github.com/mmmorris1975/aws-runas/shared"
 )
 
 const (
@@ -659,7 +661,8 @@ func (s *metadataCredentialService) getConfigAndClient(profile string) (cfg *con
 	}
 
 	if s.awsConfig != nil {
-		cfg.MergeIn(s.awsConfig)
+		s.awsConfig.MergeIn(cfg)
+		//cfg.MergeIn(s.awsConfig)
 	}
 
 	// ewww, testing-specific code in actual code


### PR DESCRIPTION
Found a config MergeIn that was reversed preventing additional credentials selections from being used and caching the original credentials incorrectly as new credentials.