### PR TITLE
Corrected a serious bug when using ec2/ecs mode potentially serving incorrect credentials

### DIFF
--- a/metadata/server.go
+++ b/metadata/server.go
@@ -659,7 +659,7 @@ func (s *metadataCredentialService) getConfigAndClient(profile string) (cfg *con
 	}
 
 	if s.awsConfig != nil {
-		cfg.MergeIn(s.awsConfig)
+		s.awsConfig.MergeIn(cfg)
 	}
 
 	// ewww, testing-specific code in actual code


### PR DESCRIPTION
Corrected a serious bug where subsequent credentials would be cached for the original role and account for all subsequent accounts and roles due to a reversed call to MergeIn() in the server code when merging credentials.