### PR TITLE
Added check for expired credentials to metadata services.   

### DIFF
--- a/metadata/server.go
+++ b/metadata/server.go
@@ -34,13 +34,12 @@ import (
 	"time"
 
 	"github.com/aws/smithy-go/logging"
-	"github.com/syndtr/gocapability/capability"
-
 	"github.com/mmmorris1975/aws-runas/client"
 	"github.com/mmmorris1975/aws-runas/config"
 	"github.com/mmmorris1975/aws-runas/credentials"
 	"github.com/mmmorris1975/aws-runas/credentials/helpers"
 	"github.com/mmmorris1975/aws-runas/shared"
+	"github.com/syndtr/gocapability/capability"
 )
 
 const (

--- a/metadata/server.go
+++ b/metadata/server.go
@@ -19,6 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/aws/smithy-go/logging"
+	"github.com/mmmorris1975/aws-runas/client"
+	"github.com/mmmorris1975/aws-runas/config"
+	"github.com/mmmorris1975/aws-runas/credentials"
+	"github.com/mmmorris1975/aws-runas/credentials/helpers"
+	"github.com/mmmorris1975/aws-runas/shared"
+	"github.com/syndtr/gocapability/capability"
 	"io"
 	"net"
 	"net/http"
@@ -32,14 +39,6 @@ import (
 	"syscall"
 	"text/template"
 	"time"
-
-	"github.com/aws/smithy-go/logging"
-	"github.com/mmmorris1975/aws-runas/client"
-	"github.com/mmmorris1975/aws-runas/config"
-	"github.com/mmmorris1975/aws-runas/credentials"
-	"github.com/mmmorris1975/aws-runas/credentials/helpers"
-	"github.com/mmmorris1975/aws-runas/shared"
-	"github.com/syndtr/gocapability/capability"
 )
 
 const (


### PR DESCRIPTION
If the credentials are within 5 min of expiration clear the cache and renew them early.   

It also allows long running tasks that need credentials to continue past the 1 hour STS credential chaining limit by providing new credentials without the need to press the refresh button on the browser UI

This also helps with the AAD provider which can take a while to auth.   

Currently no configuration for the time of the renewal it is hardcoded at anything inside the 5 min window that requests an auth will clear the cache and re-request the credentials for the ec2/ecs metadata services.