### PR TITLE
Feature/browers events rewrite of the core provider code.

### DIFF
--- a/docs/saml_client_config.md
+++ b/docs/saml_client_config.md
@@ -105,3 +105,23 @@ saml_provider = onelogin
 ```
 The app-id value can be found on the user's application landing page, hovering over the OneLogin AWS Application, and
 getting the last element in the URL path.
+
+### Browser Provider
+
+The browser provider allows for aws-runas to spawn an external browser connected to aws-runas using the Chrome Developer Protocol CDP.  This allows the user to authenticate through a browser in situations where there isn't a well defined API or where the authentication flow is fluid. AzureAD using policies that leverage tools like inTune, the use of client certificates or other security measures that have these characteristics.
+
+To use the browser provider update the `$HOME/.aws/config` file to include the following configurations.
+
+```text
+saml_auth_url = https://myapps.microsoft.com/signin/__app-id__/?tenantId=__tenant-id__
+saml_provider=browser
+auth_browser=[chrome|msedge] (optional defaults to chrome)
+```
+
+This will cause the browser to create a new hidden directory in the `$HOME/.aws/.browser/` that will store the browsers configuration and profile.  Inside of this browser data-directory a profile directory `aws-runas` will be created to store the specific session information for the browser.
+
+Once the browser is started, the user is in control of the authentication session that through the browser.  aws-runas will examine the browser events looking for the return of a `SAMLResponse=xxxx`.   Once this is found aws-runas will capture the SAMLResponse, close the browser session and use it in the same way that other providers do. 
+
+There is no way to use the existing browser SSO information since a normal browser session isn't started with a CDP enabled browser so aws-runas will not be able to monitor events and retrieve the SAML response.
+
+This provider has only been tested with AzureAD but, should work for any other provider.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.5
 	github.com/aws/smithy-go v1.13.4
+	github.com/chromedp/cdproto v0.0.0-20220924210414-0e3390be1777
 	github.com/chromedp/chromedp v0.8.6
 	github.com/dustin/go-humanize v1.0.1-0.20210705192016-249ff6c91207
 	github.com/kevinburke/ssh_config v1.2.0
@@ -40,7 +41,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 // indirect
 	github.com/aws/session-manager-plugin v0.0.0-20221012155945-c523002ee02c // indirect
-	github.com/chromedp/cdproto v0.0.0-20220924210414-0e3390be1777 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect


### PR DESCRIPTION
This upgrade allows for the SAMLResponse to be retrieved from pages that return 302 or other response codes other than just an http 200.   The prior provider would only work on pages that returned http 200.   Some users that only have a single role/account and don't select their account and role from the https://signin.aws.amazon.com/saml page but are returned a SAMLResponse via a 302 which prevented the prior version from capturing the SAMLResponse.

Also added basic configuration documentation.