### PR TITLE
browser-client-SAMLResponse: Parse response query string to get SAMLResponse key value pair

### DIFF
--- a/client/external/browser_client.go
+++ b/client/external/browser_client.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"log"
 	"net/url"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -134,7 +135,9 @@ func (c *browserClient) targetListener(ev interface{}) {
 	switch ev := ev.(type) { //nolint:gocritic
 	case *network.EventRequestWillBeSent:
 		if ev.Request.URL == `https://signin.aws.amazon.com/saml` {
-			escsaml := strings.Replace(ev.Request.PostData, `SAMLResponse=`, ``, 1)
+			// search for the SAMLResponse=xxxx using regex pattern; this ensures other key value pairs are not included in the captured string
+			r, _ := regexp.Compile("\\bSAMLResponse=([^&]+)\\b")
+			escsaml := strings.Replace(r.FindString(ev.Request.PostData), `SAMLResponse=`, ``, 1)
 			saml, err := url.QueryUnescape(escsaml)
 			if err != nil {
 				time.Sleep(time.Second * 1)


### PR DESCRIPTION
- Previously `SAMLResponse=xxxx` key value pair was selected from the POST request response data. It looked for a return of a `SAMLResponse=xxxx` examining the browser events.
- This approach works fine until the browser response doesn't send any other data in the response. 
- But some SAML providers sends out other information like `RelayState=xxxx`. If this key value pair is in the response after the `SAMLResponse=xxxx` , the captured string from the browser events would look like `SAMLResponse=xxxx&RelayState=xxxx`. This would result in a `base64` decoding error becase of the `&` character.
- Made changes to capture only the `SAMLResponse=xxxx` key value pair using regex.